### PR TITLE
disable notifications below certain level

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ handler = TelegramHandler(
 
 handler.setFormatter(formatter)
 ```
-*You can get a list of all available handler params [here](https://core.telegram.org/bots/api#sendmessage)
+*You can get a list of all available handler params [here](https://core.telegram.org/bots/api#sendmessage)*
 
 ### Use it:
 
@@ -79,5 +79,17 @@ formatter = TelegramFormatter(
         logging.DEBUG: "🐛",
         logging.INFO: "💡",
         logging.ERROR: "🚨",
-    })
+    }
+)
 ```
+
+## Notifications:
+
+You can disable telegram notification below certain logging level (https://core.telegram.org/bots/api#sendmessage). 
+```
+formatter = TelegramFormatter(
+    ...
+    notification_level=logging.WARNING
+)
+```
+This will disable notification for all logs below `WARNING` level (`DEBUG` and `INFO` will be silently delivered.)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='telegram_logging',
-      version='1.0.0',
+      version='1.0.1',
       description='Simple Telegram logging with zero dependencies.',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/telegram_logging/telegram.py
+++ b/telegram_logging/telegram.py
@@ -47,9 +47,12 @@ class TelegramHandler(logging.Handler):
                  bot_token: str,
                  chat_id: str,
                  timeout: int = 5,
+                 notification_level=logging.DEBUG,
                  **params):
         """:bot_token: Telegram bot_token\n
         :chat_id: Telegram chat_id\n
+        :timeout: Timeout for Telegram API call\n
+        :notification_level: logging level below which notification will be disabled\n
         :params: https://core.telegram.org/bots/api#sendmessage
         """
         logging.Handler.__init__(self)
@@ -58,6 +61,7 @@ class TelegramHandler(logging.Handler):
         self.timeout = timeout
         self.kwargs = params
         self.kwargs["parse_mode"] = "HTML"
+        self.notification_level = notification_level
 
     def emit(self, record):
         try:
@@ -66,6 +70,8 @@ class TelegramHandler(logging.Handler):
                 "chat_id": self.chat_id,
                 "text": self.format(record),
             }
+            if(record.levelno < self.notification_level):
+                params['disable_notification'] = True
             params.update(self.kwargs)
             data = parse.urlencode(params).encode()
             req = request.Request(url, data=data)


### PR DESCRIPTION
With this, users can disable notifications for lower-level logs. For my use case, I wanted to disable info logs, while getting notified of warnings and errors.